### PR TITLE
comment

### DIFF
--- a/qubeswhonix/__init__.py
+++ b/qubeswhonix/__init__.py
@@ -59,6 +59,8 @@ class QubesWhonixExtension(qubes.ext.Extension):
             if 'whonix-default-dispvm' in template.features:
                 default_dispvm = template.features['whonix-default-dispvm']
             else:
+                #  example template.name: whonix-ws-14
+                # example default_dispvm: whonix-ws-14-dvm
                 default_dispvm = template.name + '-dvm'
 
             if default_dispvm in app.domains:


### PR DESCRIPTION
Not sure you find this comment useful. Please reject if it violates Qubes coding standards. Me for one, I find it very helpful to see examples on what values variables might be set to.

-----

I've almost created a bug because of this, before I understood it.

`qubes-core-admin-addon-whonix default_dispvm logic error?`

https://github.com/QubesOS/qubes-core-admin-addon-whonix/blob/master/qubeswhonix/__init__.py#L62

Using non-versioned name.

    default_dispvm = template.name + '-dvm'

https://github.com/QubesOS/qubes-mgmt-salt-dom0-virtual-machines/blob/master/qvm/whonix-ws-dvm.sls

Using versioned name.

     - default-dispvm: whonix-ws-{{ whonix.whonix_version }}-dvm

So `default_dispvm = template.name + '-dvm'` might fail and cause an error?

* In best case: only leaves `default_dispvm` empty?
* In worse case: sets `default_dispvm` to bogus value (and therefore prevents VM startup)?
* In worst case: prevents VM creation?
