### PR TITLE
add missing Whonix tags anon-vm / anon-gateway to user created Whonix based VMs

### DIFF
--- a/qubeswhonix/__init__.py
+++ b/qubeswhonix/__init__.py
@@ -93,7 +93,7 @@ class QubesWhonixExtension(qubes.ext.Extension):
     def on_domain_load(self, vm, _event):
         '''Retroactively add tags to sys-whonix and anon-whonix'''
         # pylint: disable=no-self-use
-        if vm.name == 'sys-whonix' and 'anon-gateway' not in vm.tags:
+        if hasattr(vm, 'template') and 'whonix-gw' in vm.template.features and 'anon-gateway' not in vm.tags:
             vm.tags.add('anon-gateway')
-        if vm.name == 'anon-whonix' and 'anon-vm' not in vm.tags:
+        if hasattr(vm, 'template') and 'whonix-ws' in vm.template.features and 'anon-vm' not in vm.tags:
             vm.tags.add('anon-vm')


### PR DESCRIPTION
Doesn't work. For reference only.

https://github.com/QubesOS/qubes-issues/issues/4155
