### PR TITLE
Enable GUI event buffering for new Whonix-Workstation qubes

### DIFF
--- a/qubeswhonix/__init__.py
+++ b/qubeswhonix/__init__.py
@@ -73,6 +73,9 @@ class QubesWhonixExtension(qubes.ext.Extension):
                              'not exists', default_dispvm)
                 vm.default_dispvm = None
 
+            if 'gui-events-max-delay' not in vm.features:
+                vm.features['gui-events-max-delay'] = 100
+
     @qubes.ext.handler('features-request')
     def on_features_request(self, vm, _event, untrusted_features):
         '''Handle whonix-ws/whonix-gw template advertising itself'''
@@ -89,10 +92,15 @@ class QubesWhonixExtension(qubes.ext.Extension):
 
     @qubes.ext.handler('domain-load')
     def on_domain_load(self, vm, _event):
-        '''Retroactively add tags to sys-whonix and anon-whonix'''
+        '''Retroactively add tags to sys-whonix and anon-whonix. Also enable
+        event buffering if it's not already enabled.
+        '''
         if hasattr(vm, 'template') and 'whonix-gw' in vm.template.features \
                 and 'anon-gateway' not in vm.tags:
             vm.tags.add('anon-gateway')
         if hasattr(vm, 'template') and 'whonix-ws' in vm.template.features \
                 and 'anon-vm' not in vm.tags:
             vm.tags.add('anon-vm')
+        if hasattr(vm, 'template') and 'whonix-ws' in vm.template.features \
+            and 'gui-events-max-delay' not in vm.features:
+            vm.features['gui-events-max-delay'] = 100


### PR DESCRIPTION
Pretty much as straightforward as it gets. Tested by installing in dom0 on Qubes R4.3, then rebooting, then creating a new qube based on the whonix-workstation-17 template. `gui-events-max-delay` feature was set to `100` as expected and keyboard input into apps within the qube had noticeable jitter as desired.

Fixes https://github.com/QubesOS/qubes-issues/issues/9771