### PR TITLE
Rework for new sdwdate-gui architecture

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,5 @@ all:
 install:
 	# force /usr/bin before /bin to have /usr/bin/python instead of /bin/python
 	PATH="/usr/bin:$$PATH" python3 setup.py install $(PYTHON_PREFIX_ARG) -O1 --skip-build --root $(DESTDIR)
-	mkdir -p $(DESTDIR)/etc/qubes-rpc/policy
-	cp qubes-rpc-policy/whonix.GatewayCommand.policy $(DESTDIR)/etc/qubes-rpc/policy/whonix.GatewayCommand
-	cp qubes-rpc-policy/whonix.NewStatus.policy $(DESTDIR)/etc/qubes-rpc/policy/whonix.NewStatus
-	cp qubes-rpc-policy/whonix.SdwdateStatus.policy $(DESTDIR)/etc/qubes-rpc/policy/whonix.SdwdateStatus
 	mkdir -p $(DESTDIR)/etc/qubes/policy.d/
 	cp qubes-rpc-policy/80-whonix.policy $(DESTDIR)/etc/qubes/policy.d/80-whonix.policy

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ is created based on a template with `whonix-ws` feature set, it gets:
  - default dispvm set to name of the template + `-dvm` (can be overriden by
    `whonix-default-dispvm` feature on the template)
  - tag `anon-vm` used by various qrexec policies
+ - tag `sdwdate-gui-client` used for sdwdate-gui qrexec functions.
 
 If any of referenced VM does not exists, extension set relevant property to
 none, to not risk leaking data over clearnet.
@@ -15,6 +16,7 @@ none, to not risk leaking data over clearnet.
 Similarly, new Whonix Gateway is configured. When new VM is created based on a
 template with `whonix-gw` feature set it gets:
  - `anon-gateway` tag
+ - `sdwdate-gui-server` tag
 
 Additionally, Whonix Gateway/Workstation template can request `whonix-ws` feature to be
 added to itself, easing bootstrap of this feature. The canonical way to do

--- a/qubes-rpc-policy/80-whonix.policy
+++ b/qubes-rpc-policy/80-whonix.policy
@@ -5,3 +5,17 @@ sdwdate.ConnectCheck *   @tag:sdwdate-gui-client @tag:sdwdate-gui-server allow  
 
 sdwdate.Connect      *   @anyvm                  @anyvm                  deny
 sdwdate.ConnectCheck *   @anyvm                  @anyvm                  deny
+
+# Legacy, all of these services should effectively be no-ops for fully updated
+# Whonix-Gateway and Whonix-Workstation qubes.
+whonix.SdwdateStatus +         @tag:anon-gateway @tag:anon-vm      allow  autostart=no notify=no
+whonix.SdwdateStatus +         @tag:anon-gateway @default          deny   notify=no
+whonix.SdwdateStatus +         @anyvm            @anyvm            deny
+
+whonix.NewStatus     *         @tag:anon-vm      @tag:anon-gateway allow  autostart=no
+whonix.NewStatus     *         @anyvm            @anyvm            deny
+
+whonix.GatewayCommand +restart @tag:anon-gateway @tag:anon-vm      allow  autostart=no
+whonix.GatewayCommand +stop    @tag:anon-gateway @tag:anon-vm      allow  autostart=no
+whonix.GatewayCommand +showlog @tag:anon-gateway @tag:anon-vm      allow  autostart=no
+whonix.GatewayCommand *        @anyvm            @anyvm            deny

--- a/qubes-rpc-policy/80-whonix.policy
+++ b/qubes-rpc-policy/80-whonix.policy
@@ -1,13 +1,7 @@
-# service            arg       source            target            action params
+# service            arg source                  target                  action params
 
-whonix.SdwdateStatus +         @tag:anon-gateway @tag:anon-vm      allow  autostart=no notify=no
-whonix.SdwdateStatus +         @tag:anon-gateway @default          deny   notify=no
-whonix.SdwdateStatus +         @anyvm            @anyvm            deny
+sdwdate.Connect      *   @tag:sdwdate-gui-client @tag:sdwdate-gui-server allow  autostart=no notify=no
+sdwdate.ConnectCheck *   @tag:sdwdate-gui-client @tag:sdwdate-gui-server allow  autostart=no notify=no
 
-whonix.NewStatus     *         @tag:anon-vm      @tag:anon-gateway allow  autostart=no
-whonix.NewStatus     *         @anyvm            @anyvm            deny
-
-whonix.GatewayCommand +restart @tag:anon-gateway @tag:anon-vm      allow  autostart=no
-whonix.GatewayCommand +stop    @tag:anon-gateway @tag:anon-vm      allow  autostart=no
-whonix.GatewayCommand +showlog @tag:anon-gateway @tag:anon-vm      allow  autostart=no
-whonix.GatewayCommand *        @anyvm            @anyvm            deny
+sdwdate.Connect      *   @anyvm                  @anyvm                  deny
+sdwdate.ConnectCheck *   @anyvm                  @anyvm                  deny

--- a/qubes-rpc-policy/whonix.GatewayCommand.policy
+++ b/qubes-rpc-policy/whonix.GatewayCommand.policy
@@ -1,2 +1,0 @@
-# Legacy. This file does nothing and will be removed in a future release. See:
-# /etc/qubes/policy.d/80-whonix.policy

--- a/qubes-rpc-policy/whonix.NewStatus.policy
+++ b/qubes-rpc-policy/whonix.NewStatus.policy
@@ -1,2 +1,0 @@
-# Legacy. This file does nothing and will be removed in a future release. See:
-# /etc/qubes/policy.d/80-whonix.policy

--- a/qubes-rpc-policy/whonix.SdwdateStatus.policy
+++ b/qubes-rpc-policy/whonix.SdwdateStatus.policy
@@ -1,2 +1,0 @@
-# Legacy. This file does nothing and will be removed in a future release. See:
-# /etc/qubes/policy.d/80-whonix.policy

--- a/qubeswhonix/__init__.py
+++ b/qubeswhonix/__init__.py
@@ -36,11 +36,13 @@ class QubesWhonixExtension(qubes.ext.Extension):
 
         if 'whonix-gw' in template.features:
             vm.tags.add('anon-gateway')
+            vm.tags.add('sdwdate-gui-server')
 
         if 'whonix-ws' in template.features:
             # this is new VM based on whonix-ws, adjust its default settings
 
             vm.tags.add('anon-vm')
+            vm.tags.add('sdwdate-gui-client')
 
             # look for appropriate whonix-gateway
             if 'whonix-default-gw' in template.features:
@@ -95,12 +97,16 @@ class QubesWhonixExtension(qubes.ext.Extension):
         '''Retroactively add tags to sys-whonix and anon-whonix. Also enable
         event buffering if it's not already enabled.
         '''
-        if hasattr(vm, 'template') and 'whonix-gw' in vm.template.features \
-                and 'anon-gateway' not in vm.tags:
-            vm.tags.add('anon-gateway')
-        if hasattr(vm, 'template') and 'whonix-ws' in vm.template.features \
-                and 'anon-vm' not in vm.tags:
-            vm.tags.add('anon-vm')
+        if hasattr(vm, 'template') and 'whonix-gw' in vm.template.features:
+            if 'anon-gateway' not in vm.tags:
+                vm.tags.add('anon-gateway')
+            if 'sdwdate-gui-server' not in vm.tags:
+                vm.tags.add('sdwdate-gui-server')
+        if hasattr(vm, 'template') and 'whonix-ws' in vm.template.features:
+            if 'anon-vm' not in vm.tags:
+                vm.tags.add('anon-vm')
+            elif 'sdwdate-gui-client' not in vm.tags:
+                vm.tags.add('sdwdate-gui-client')
         if hasattr(vm, 'template') and 'whonix-ws' in vm.template.features \
             and 'gui-events-max-delay' not in vm.features:
             vm.features['gui-events-max-delay'] = 100

--- a/rpm_spec/qubes-core-admin-addon-whonix.spec.in
+++ b/rpm_spec/qubes-core-admin-addon-whonix.spec.in
@@ -31,10 +31,6 @@ make %{?_smp_mflags}
 %doc README.md
 %{python3_sitelib}/qubeswhonix-*.egg-info
 %{python3_sitelib}/qubeswhonix
-# legacy 4.0 policy format
-%attr(0664,root,qubes) %config(noreplace) /etc/qubes-rpc/policy/whonix.GatewayCommand
-%attr(0664,root,qubes) %config(noreplace) /etc/qubes-rpc/policy/whonix.NewStatus
-%attr(0664,root,qubes) %config(noreplace) /etc/qubes-rpc/policy/whonix.SdwdateStatus
 # new 5.0 policy format
 %attr(0664,root,qubes) %config(noreplace) /etc/qubes/policy.d/80-whonix.policy
 


### PR DESCRIPTION
sdwdate-gui has been rewritten to use a more efficient architecture that isn't entirely Whonix-specific. Adjust configuration and VM tags for compatibility with the new architecture.

Part of the fix for https://github.com/QubesOS/qubes-issues/issues/7447. Related to https://github.com/QubesOS/qubes-issues/issues/10020.