### PR TITLE
Disallow dangerous qrexec operations

### DIFF
--- a/qubes-rpc-policy/80-whonix.policy
+++ b/qubes-rpc-policy/80-whonix.policy
@@ -11,3 +11,21 @@ whonix.GatewayCommand +restart @tag:anon-gateway @tag:anon-vm      allow  autost
 whonix.GatewayCommand +stop    @tag:anon-gateway @tag:anon-vm      allow  autostart=no
 whonix.GatewayCommand +showlog @tag:anon-gateway @tag:anon-vm      allow  autostart=no
 whonix.GatewayCommand *        @anyvm            @anyvm            deny
+
+# Harden against potential IP leaks by not allowing a compromised
+# Whonix-Workstation to open files, URLs, or applications in VMs other than
+# Whonix-Workstation VMs (typically DispVMs).
+qubes.OpenInVM        *        @tag:anon-vm      @dispvm           ask    default_target=@dispvm
+qubes.OpenInVM        *        @tag:anon-vm      @tag:anon-vm      ask
+qubes.OpenInVM        *        @tag:anon-vm      @default          ask
+qubes.OpenInVM        *        @tag:anon-vm      @anyvm            deny
+
+qubes.OpenURL         *        @tag:anon-vm      @dispvm           ask    default_target=@dispvm
+qubes.OpenURL         *        @tag:anon-vm      @tag:anon-vm      ask
+qubes.OpenURL         *        @tag:anon-vm      @default          ask
+qubes.OpenURL         *        @tag:anon-vm      @anyvm            deny
+
+qubes.StartApp        *        @tag:anon-vm      @dispvm           ask    default_target=@dispvm
+qubes.StartApp        *        @tag:anon-vm      @tag:anon-vm      ask
+qubes.StartApp        *        @tag:anon-vm      @default          ask
+qubes.StartApp        *        @tag:anon-vm      @anyvm            deny


### PR DESCRIPTION
Whonix-Workstation should never need to open a file, URL, or application in anything other than a Whonix-Workstation disposable VM. Allowing it to even ask to do one of these actions in an unsafe way is dangerous, since a user who isn't paying enough attention might allow the request and leak their IP address in so doing (for instance, by visiting an attacker-provided URL in a VM that has clearnet access). Don't allow Whonix-Workstation to take (or ask to take) any of these dangerous actions.

Implements https://github.com/QubesOS/qubes-issues/issues/10051.