### PR TITLE
Increase default initial memory for Whonix workstation

### DIFF
--- a/qubeswhonix/__init__.py
+++ b/qubeswhonix/__init__.py
@@ -133,6 +133,11 @@ class QubesWhonixExtension(qubes.ext.Extension):
         if 'whonix-ws' in untrusted_features:
             vm.features['whonix-ws'] = True
             vm.tags.add('whonix-updatevm')
+            if vm.property_is_default("memory"):
+                # Whonix workstation starts more things on boot and as such
+                # needs more memory to properly start (without excessive
+                # swapping):
+                vm.memory = 500
 
     @qubes.ext.handler('domain-load')
     def on_domain_load(self, vm, _event):


### PR DESCRIPTION
It appears that Whonix workstation starts more things on boot, and with
default 400M initial memory it's swapping quite a bit, resulting in slow
startup. Increase default memory for it, but only if user hasn't
modified it before already. The template's value is used as default for
app qubes based on it, so it's enough to adjust on the template.

Note this will also apply to existing templates, at next update, as
features are re-requested on each update.