### PR TITLE
Rename sdwdate.Connect(Check) to sdwdate-gui.Connect(Check)

### DIFF
--- a/qubes-rpc-policy/80-whonix.policy
+++ b/qubes-rpc-policy/80-whonix.policy
@@ -1,13 +1,19 @@
 # service            arg source                  target                  action params
 
+sdwdate-gui.Connect      *   @tag:sdwdate-gui-client @tag:sdwdate-gui-server allow  autostart=no notify=no
+sdwdate-gui.ConnectCheck *   @tag:sdwdate-gui-client @tag:sdwdate-gui-server allow  autostart=no notify=no
+
+sdwdate-gui.Connect      *   @anyvm                  @anyvm                  deny
+sdwdate-gui.ConnectCheck *   @anyvm                  @anyvm                  deny
+
+# Legacy, all of these services should effectively be no-ops for fully updated
+# Whonix-Gateway and Whonix-Workstation qubes.
 sdwdate.Connect      *   @tag:sdwdate-gui-client @tag:sdwdate-gui-server allow  autostart=no notify=no
 sdwdate.ConnectCheck *   @tag:sdwdate-gui-client @tag:sdwdate-gui-server allow  autostart=no notify=no
 
 sdwdate.Connect      *   @anyvm                  @anyvm                  deny
 sdwdate.ConnectCheck *   @anyvm                  @anyvm                  deny
 
-# Legacy, all of these services should effectively be no-ops for fully updated
-# Whonix-Gateway and Whonix-Workstation qubes.
 whonix.SdwdateStatus +         @tag:anon-gateway @tag:anon-vm      allow  autostart=no notify=no
 whonix.SdwdateStatus +         @tag:anon-gateway @default          deny   notify=no
 whonix.SdwdateStatus +         @anyvm            @anyvm            deny


### PR DESCRIPTION
Corresponding commit for Whonix in my sdwdate-gui dev repo: https://github.com/ArrayBolt3/sdwdate-gui/commit/2dc019a1e6967d55ca8a8cfd8e24a35e269bab10

Fixes https://github.com/QubesOS/qubes-issues/issues/10346.

(Note, I had thought that a qubes-core-admin-addon-kicksecure PR would also be needed, but because we aren't changing the VM tags used for authorizing sdwdate-gui communication, this is actually the only Qubes-side PR needed.)