### PR TITLE
Make update for qrexec policy more reliable

### DIFF
--- a/qubes-rpc-policy/80-whonix.policy
+++ b/qubes-rpc-policy/80-whonix.policy
@@ -1,3 +1,6 @@
+## Do not modify this file, create a new policy file with a lower number in the
+## filename instead. For example `30-user.policy`.
+
 # service            arg source                  target                  action params
 
 sdwdate-gui.Connect      *   @tag:sdwdate-gui-client @tag:sdwdate-gui-server allow  autostart=no notify=no

--- a/rpm_spec/qubes-core-admin-addon-whonix.spec.in
+++ b/rpm_spec/qubes-core-admin-addon-whonix.spec.in
@@ -32,7 +32,7 @@ make %{?_smp_mflags}
 %{python3_sitelib}/qubeswhonix-*.egg-info
 %{python3_sitelib}/qubeswhonix
 # new 5.0 policy format
-%attr(0664,root,qubes) %config(noreplace) /etc/qubes/policy.d/80-whonix.policy
+%attr(0664,root,qubes) %config /etc/qubes/policy.d/80-whonix.policy
 
 %changelog
 


### PR DESCRIPTION
We've got reports that new policy got saved in .rpmnew file even when user didn't (intentionally) modified the file. That happened only because a policy editor stripped final newline, which was enough to not apply the update.
Make the package always update the policy file to avoid such issues.

See commit messages for details.