### PR TITLE
Fix a default_dispvm autodetect failure

### DIFF
--- a/qubeswhonix/__init__.py
+++ b/qubeswhonix/__init__.py
@@ -88,7 +88,10 @@ class QubesWhonixExtension(qubes.ext.Extension):
             ):
                 # If any VM in template chain has the special feature, use it.
                 default_dispvm = feature
-            elif template is not None:
+            elif (
+                template is not None
+                and (template.name + "-dvm") in app.domains
+            ):
                 # If we have a template, use it for assuming a name.
                 default_dispvm = template.name + "-dvm"
             else:


### PR DESCRIPTION
If the user has a Whonix-Workstation template with a name such that (template_name + "-dvm") does not point to an existing VM, qubes-core-admin-addon-whonix will try to set a default DispVM for the new AppVM that doesn't exist. This results in an error, and the default DispVM ends up being set to None.

Make sure that the default DispVM name we're about to set actually exists before we set it. If it doesn't, fall back to the hardcoded `whonix-workstation-18-dvm` value.